### PR TITLE
Add boxes coordinates compliant with the final output format

### DIFF
--- a/model.py
+++ b/model.py
@@ -194,7 +194,9 @@ class LSCCNN(nn.Module):
             out = self.forward(img_tensor.cuda())
         out = get_upsample_output(out, self.output_downscale)
         pred_dot_map, pred_box_map = get_box_and_dot_maps(out, nms_thresh, self.BOXES)
-        img_out = get_boxed_img(image, pred_box_map, pred_box_map, pred_dot_map, self.output_downscale,
-                                self.BOXES, self.BOX_SIZE_BINS, thickness=thickness, multi_colours=multi_colours)
-        return pred_dot_map, pred_box_map, img_out
+        pred_box_map_out, img_out = get_boxed_img(image, pred_box_map, pred_box_map, pred_dot_map,
+                                                  self.output_downscale,
+                                                  self.BOXES, self.BOX_SIZE_BINS, thickness=thickness,
+                                                  multi_colours=multi_colours)
+        return pred_dot_map, pred_box_map, pred_box_map_out, img_out
 

--- a/utils_model.py
+++ b/utils_model.py
@@ -116,6 +116,11 @@ def get_boxed_img(image, h_map, w_map, gt_pred_map, prediction_downscale, BOXES,
             t = 1
         else:
             t = thickness
-        cv2.rectangle(boxed_img, (max(int(prediction_downscale * x - w / 2), 0), max(int(prediction_downscale * y - h / 2), 0)),
-                      (min(int(prediction_downscale * x + w - w / 2), W), min(int(prediction_downscale * y + h - h / 2), H)), selected_colour, t)
-    return boxed_img#.transpose((2, 0, 1))
+        new_x = max(int(prediction_downscale * x - w / 2), 0)
+        new_y = max(int(prediction_downscale * y - h / 2), 0)
+        new_h = min(int(prediction_downscale * x + w - w / 2), W)
+        new_w = min(int(prediction_downscale * y + h - h / 2), H)
+        rectangles.append((new_x, new_y, new_h, new_w))
+        cv2.rectangle(boxed_img, (new_x, new_y), (new_h, new_w), selected_colour, t)
+
+    return (rectangles, boxed_img)


### PR DESCRIPTION
"pred_map_box" is defined in the space of the network output, and in a weird shape. I found interesting to return boxes as defined in the final output. 
